### PR TITLE
Prep release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,47 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: DumME
+message: >-
+  This is an adaptation of existing software. Please also refer to the original.
+type: software
+authors:
+  - given-names: Peter
+    family-names: Kalverla
+    email: p.kalverla@esciencecenter.nl
+    affiliation: Netherland eScience Center
+    orcid: 'https://orcid.org/0000-0002-5025-7862'
+  - given-names: Stefan
+    family-names: Verhoeven
+    email: s.verhoeven@esciencecenter.nl
+    affiliation: Netherlands eScience Center
+    orcid: 'https://orcid.org/0000-0002-5821-2060'
+repository-code: 'https://github.com/phenology/dumme'
+abstract: >-
+  This is an adaptation of MERF (https://github.com/manifoldai/merf). The main
+  difference is that this version is fully compliant with the scikit-learn API.
+
+  Other difference include:
+
+  - The name: MERF was renamed to the more general MixedEffectsModel
+  - The default fixed-effects model: dummy model instead of random forest
+  - The package structure: stripped down to its core and then upgraded to use
+    modern standards
+  - Test suite: using pytest instead of unittest
+license: MIT
+commit: 456dfe7
+version: '0.1'
+date-released: '2024-01-26'
+references:
+  - authors:
+      - family-names: Dey
+        given-names: Sourav
+      - family-names: Grover
+        given-names: Prince
+      - family-names: Rose
+        given-names: Stephen Anthony
+    title: "Mixed Effects Random Forest"
+    type: software
+    version: 1.0
+    repository-code: https://github.com/manifoldai/merf

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -31,8 +31,8 @@ abstract: >-
   - Test suite: using pytest instead of unittest
 license: MIT
 commit: 456dfe7
-version: '0.1'
-date-released: '2024-01-26'
+version: '0.1.0'
+date-released: '2024-01-30'
 references:
   - authors:
       - family-names: Dey

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
-Copyright (c) 2019 Manifold
 Copyright (c) 2024 Netherlands eScience Center
+Copyright (c) 2019 Manifold
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2019 Manifold
+Copyright (c) 2024 Netherlands eScience Center
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,24 +1,20 @@
 # DumME: Mixed Effects Dummy Model
 
-This is an adaptation of https://github.com/manifoldai/merf. The most important changes are:
+This is an adaptation of MERF (https://github.com/manifoldai/merf). The main
+difference is that this version is fully compliant with the scikit-learn API.
 
-* This version is (mostly) [SKlearn
-  compliant](https://scikit-learn.org/stable/developers/develop.html) and can
-  therefore be used with other frameworks such as
-  [pycaret](https://pycaret.gitbook.io/docs/).
-  * Fit API starts with X and y; Z and clusters are removed. Instead, optional
-    kwargs to specify the columns of 'clusters', 'fixed_effects', and
-    'random_effects'.
-  * Predict only accepts X as input. It is assumed new data is structured in the
-    same way as the original training data.
-* The main class was renamed to MixedEffectsModel (more general) with the
-  scikit-learn dummy model as default.
-* Package trimmed down to bare minimum but with modern package structure
+Other difference include:
+
+- The name: MERF was renamed to the more general MixedEffectsModel
+- The default fixed-effects model: dummy model instead of random forest
+- The package structure: stripped down to its core and then upgraded to use
+  modern standards
+- Test suite: using pytest instead of unittest
 
 > [!CAUTION]
-> We don't intend to maintain or develop this further. However, we are happy to
-> contribute our changes to the original version of MERF.
-> Notice https://github.com/manifoldai/merf/issues/68.
+> We currently don't plan on maintaining or developing this further. However, we
+> are happy to contribute our changes to the original version of MERF. Notice
+> https://github.com/manifoldai/merf/issues/68.
 
 ## Using this version
 
@@ -41,11 +37,17 @@ y = df.pop("y")
 x = df
 
 # Fit a dummy model
+# Notice the signature of the `fit` method: first X and y, and the other args are optional.
 me_dummy = MixedEffectsModel()
-me_dummy.fit(X, y)  # This works now
+me_dummy.fit(X, y)
 
-# But you can still pass in additional arguments
+# or
 me_dummy.fit(X, y, cluster_column="cluster", fixed_effects=["X_0", "X_1", "X_2"], random_effects=["Z"])
+
+# Predict only accepts X as input. It is assumed new data is structured
+# in the same way as the original training data.
+new_X = X.copy()
+me_dummy.predict(new_X)
 ```
 
 To get the "original" MERF (but still with the new fit signature):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "dumme"
-version = "1.0.1"
+name = "DumME"
+version = "0.1.0"
 dependencies = [
   "pandas>=1.0",
   "numpy>=1.20",
@@ -12,12 +12,12 @@ dependencies = [
   "matplotlib>=3.0",
   "lightgbm",
 ]
-description="Mixed Effects Model"
+description="Mixed Effects Dummy Model"
 readme="README.md"
 requires-python = '>=3.9'
 authors = [
-  {name = "Manifold, Inc.", email = "sdey@manifold.ai"},
   {name = "Peter Kalverla.", email = "p.kalverla@esciencecenter.nl"},
+  {name = "Stefan Verhoeven.", email = "s.verhoeven@esciencecenter.nl"},
 ]
 license = {file = "LICENSE.txt"}
 keywords=["random forest", "machine learning", "mixed effects"]
@@ -32,7 +32,7 @@ classifiers=[
 dev = ["black", "ruff", "isort", "pytest", "pycaret"]
 
 [project.urls]
-Repository="https://github.com/phenology/merf"
+Repository="https://github.com/phenology/dumme"
 Original="https://github.com/manifoldai/merf"
 
 [tool.isort]

--- a/src/dumme/dumme.py
+++ b/src/dumme/dumme.py
@@ -20,28 +20,26 @@ logger = logging.getLogger(__name__)
 # BaseEstimator has boilerplate for things like get_params, set_params, _validate_data
 class MixedEffectsModel(RegressorMixin, BaseEstimator):
     """
-    This is the core class to instantiate, train, and predict using a mixed effects random forest model.
-    It roughly adheres to the sklearn estimator API.
-    Note that the user must pass in an already instantiated fixed_effects_model that adheres to the
-    sklearn regression estimator API, i.e. must have a fit() and predict() method defined.
-
-    It assumes a data model of the form:
+    Scikit-learn compatbile implementation of a mixed-effects model of the form
 
     .. math::
 
         y = f(X) + b_i Z + e
 
-    * y is the target variable. The current code only supports regression for now, e.g. continuously varying scalar value
+    * y is the target variable. The current code only supports regression for
+      now, e.g. continuously varying scalar value
     * X is the fixed effect features. Assume p dimensional
     * f(.) is the nonlinear fixed effects mode, e.g. random forest
     * Z is the random effect features. Assume q dimensional.
     * e is iid noise ~N(0, sigma_e²)
     * i is the cluster index. Assume k clusters in the training.
-    * bi is the random effect coefficients. They are different per cluster i but are assumed to be drawn from the same distribution ~N(0, Sigma_b) where Sigma_b is learned from the data.
+    * bi is the random effect coefficients. They are different per cluster i but
+      are assumed to be drawn from the same distribution ~N(0, Sigma_b) where
+      Sigma_b is learned from the data.
 
     Args:
-        gll_early_stop_threshold (float): early stopping threshold on GLL improvement
-        max_iterations (int): maximum number of EM iterations to train
+        gll_early_stop_threshold (float): early stopping threshold on GLL
+        improvement max_iterations (int): maximum number of EM iterations
     """
 
     def __init__(


### PR DESCRIPTION
Adding metadata to make a release of this adapted version of MERF.

* Taken care to respect the license terms of the original and to include the original in the citation metadata.
* Reset version to 0.1.0 to signal that this is a different package and the API is unstable
* Changed name of project/repo to DumME: Mixed Effects Dummy Model
* Switch is flipped on Zenodo